### PR TITLE
Feat/13/dashboard header

### DIFF
--- a/src/app/mydashboard/layout.tsx
+++ b/src/app/mydashboard/layout.tsx
@@ -1,11 +1,12 @@
 import Sidebar from '@/components/Sidebar/Sidebar';
 import { ReactNode } from 'react';
+import Header from '@/components/dashboard-header/Header';
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (
     <div className='flex'>
       <Sidebar />
-
+      <Header title='나의 대시보드' showCrown showSetting showUsers showProfile />
       <main className='flex-1'>{children}</main>
     </div>
   );

--- a/src/app/mydashboard/layout.tsx
+++ b/src/app/mydashboard/layout.tsx
@@ -6,7 +6,7 @@ export default function Layout({ children }: { children: ReactNode }) {
   return (
     <div className='flex'>
       <Sidebar />
-      <Header showCrown showSetting showUsers showProfile />
+      <Header showCrown showSetting showMembers showProfile />
       <main className='flex-1'>{children}</main>
     </div>
   );

--- a/src/app/mydashboard/layout.tsx
+++ b/src/app/mydashboard/layout.tsx
@@ -6,7 +6,7 @@ export default function Layout({ children }: { children: ReactNode }) {
   return (
     <div className='flex'>
       <Sidebar />
-      <Header title='나의 대시보드' showCrown showSetting showUsers showProfile />
+      <Header showCrown showSetting showUsers showProfile />
       <main className='flex-1'>{children}</main>
     </div>
   );

--- a/src/components/dashboard-header/Header.tsx
+++ b/src/components/dashboard-header/Header.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import React from 'react';
+import Image from 'next/image';
+import Crown from '@/assets/icons/crown.svg';
+import Title from './Title';
+import SettingBtn from './SettingBtn';
+
+interface HeaderProps {
+  title?: string;
+  showCrown?: boolean;
+  showSetting?: boolean;
+  showUsers?: boolean;
+  showProfile?: boolean;
+}
+
+// API 연동 이후 추가 작업 예정, 우선 mock 데이터로 집어넣어놨습니다.
+interface UserType {
+  nickname: string;
+  profileImageUrl: string;
+}
+
+const mockUser: UserType = {
+  nickname: '배유철',
+  profileImageUrl: 'B',
+};
+
+export default function Header({ title, showCrown = false, showSetting = false, showUsers = false, showProfile = false }: HeaderProps) {
+  const handleSettingClick = () => {
+    console.log('관리 버튼 클릭');
+  };
+
+  const handleInviteClick = () => {
+    console.log('초대 버튼 클릭');
+  };
+
+  const handleProfileClick = () => {
+    console.log('프로필 버튼 클릭');
+  };
+
+  return (
+    <header className='flex h-[60px] w-full items-center justify-between border-b-2 border-gray-20 py-[15.5px] sm:h-[70px] sm:px-[40px]'>
+      {/* 왼쪽 제목 그룹 */}
+      <div className='flex items-center gap-[8px]'>
+        <Title title={title} />
+        {showCrown && <Image src={Crown} alt='방장 표시' className='hidden h-[16px] w-[20px] lg:block' />}
+      </div>
+      {/* 오른쪽 버튼 그룹 */}
+      <div className='flex items-center'>
+        <>
+          <div className='flex items-center gap-[16px] border-r border-gray-30 pr-[12px] sm:gap-[32px] sm:pr-[24px] md:gap-[40px] md:pr-[32px]'>
+            {showSetting && <SettingBtn onSettingClick={handleSettingClick} onInviteClick={handleInviteClick} />}
+            {showUsers && (
+              <div className='flex'>
+                <span className='-ml-[8px] flex h-[34px] w-[34px] items-center justify-center rounded-full border-2 border-white bg-green-30 text-white sm:h-[38px] sm:w-[38px]'>
+                  {mockUser.profileImageUrl}
+                </span>
+                <span className='-ml-[8px] flex h-[34px] w-[34px] items-center justify-center rounded-full border-2 border-white bg-green-30 text-white sm:h-[38px] sm:w-[38px]'>
+                  {mockUser.profileImageUrl}
+                </span>
+                <span className='-ml-[8px] flex h-[34px] w-[34px] items-center justify-center rounded-full border-2 border-white bg-green-30 text-white sm:h-[38px] sm:w-[38px]'>
+                  {mockUser.profileImageUrl}
+                </span>
+              </div>
+            )}
+          </div>
+          {showProfile && (
+            <button onClick={handleProfileClick} className='mr-[40px] flex items-center justify-center gap-[12px] pl-[12px] sm:pl-[24px] md:pl-[32px]'>
+              <span className='flex h-[34px] w-[34px] items-center justify-center rounded-full border-2 border-white bg-green-30 text-white sm:h-[38px] sm:w-[38px]'>{mockUser.profileImageUrl}</span>
+              <span className='hidden text-[16px] md:block'>{mockUser.nickname}</span>
+            </button>
+          )}
+        </>
+      </div>
+    </header>
+  );
+}

--- a/src/components/dashboard-header/Header.tsx
+++ b/src/components/dashboard-header/Header.tsx
@@ -20,7 +20,7 @@ const titleMap: { [key: string]: string } = {
   '/mypage': '계정관리',
 };
 
-// API 연동 이후 추가 작업 예정, 우선 mock 데이터로 집어넣어놨습니다.
+// TODO : API 연동 이후 추가 작업 예정, 우선 mock 데이터로 집어넣어놨습니다.
 interface UserType {
   nickname: string;
   profileImageUrl: string;
@@ -36,14 +36,17 @@ export default function Header({ showCrown = false, showSetting = false, showUse
   const title = titleMap[pathname] || '내 대시보드';
   const handleSettingClick = () => {
     console.log('관리 버튼 클릭');
+    // TODO : 디버깅 용도 console.log API 기능 구현 후 수정 예정
   };
 
   const handleInviteClick = () => {
     console.log('초대 버튼 클릭');
+    // TODO : 디버깅 용도 console.log API 기능 구현 후 수정 예정
   };
 
   const handleProfileClick = () => {
     console.log('프로필 버튼 클릭');
+    // TODO : 디버깅 용도 console.log API 기능 구현 후 수정 예정
   };
 
   return (
@@ -51,7 +54,7 @@ export default function Header({ showCrown = false, showSetting = false, showUse
       {/* 왼쪽 제목 그룹 */}
       <div className='flex items-center gap-[8px]'>
         <Title title={title} />
-        {showCrown && <Image src={Crown} alt='방장 표시' className='hidden h-[16px] w-[20px] lg:block' />}
+        {showCrown && <Image src={Crown} alt='방장 표시' width={20} height={16} className='hidden lg:block' />}
       </div>
       {/* 오른쪽 버튼 그룹 */}
       <div className='flex items-center'>

--- a/src/components/dashboard-header/Header.tsx
+++ b/src/components/dashboard-header/Header.tsx
@@ -6,12 +6,14 @@ import Image from 'next/image';
 import Crown from '@/assets/icons/crown.svg';
 import Title from './Title';
 import SettingBtn from './SettingBtn';
+import Members from './Members';
+import Profile from './Profile';
 
 interface HeaderProps {
   title?: string;
   showCrown?: boolean;
   showSetting?: boolean;
-  showUsers?: boolean;
+  showMembers?: boolean;
   showProfile?: boolean;
 }
 
@@ -26,12 +28,13 @@ interface UserType {
   profileImageUrl: string;
 }
 
-const mockUser: UserType = {
-  nickname: '배유철',
-  profileImageUrl: 'B',
-};
+const mockUsers: UserType[] = [
+  { nickname: '배유철', profileImageUrl: 'B' },
+  { nickname: '김철수', profileImageUrl: 'K' },
+  { nickname: '이영희', profileImageUrl: 'L' },
+];
 
-export default function Header({ showCrown = false, showSetting = false, showUsers = false, showProfile = false }: HeaderProps) {
+export default function Header({ showCrown = false, showSetting = false, showMembers = false, showProfile = false }: HeaderProps) {
   const pathname = usePathname();
   const title = titleMap[pathname] || '내 대시보드';
   const handleSettingClick = () => {
@@ -58,30 +61,11 @@ export default function Header({ showCrown = false, showSetting = false, showUse
       </div>
       {/* 오른쪽 버튼 그룹 */}
       <div className='flex items-center'>
-        <>
-          <div className='flex items-center gap-[16px] border-r border-gray-30 pr-[12px] sm:gap-[32px] sm:pr-[24px] md:gap-[40px] md:pr-[32px]'>
-            {showSetting && <SettingBtn onSettingClick={handleSettingClick} onInviteClick={handleInviteClick} />}
-            {showUsers && (
-              <div className='flex'>
-                <span className='-ml-[8px] flex h-[34px] w-[34px] items-center justify-center rounded-full border-2 border-white bg-green-30 text-white sm:h-[38px] sm:w-[38px]'>
-                  {mockUser.profileImageUrl}
-                </span>
-                <span className='-ml-[8px] flex h-[34px] w-[34px] items-center justify-center rounded-full border-2 border-white bg-green-30 text-white sm:h-[38px] sm:w-[38px]'>
-                  {mockUser.profileImageUrl}
-                </span>
-                <span className='-ml-[8px] flex h-[34px] w-[34px] items-center justify-center rounded-full border-2 border-white bg-green-30 text-white sm:h-[38px] sm:w-[38px]'>
-                  {mockUser.profileImageUrl}
-                </span>
-              </div>
-            )}
-          </div>
-          {showProfile && (
-            <button onClick={handleProfileClick} className='mr-[40px] flex items-center justify-center gap-[12px] pl-[12px] sm:pl-[24px] md:pl-[32px]'>
-              <span className='flex h-[34px] w-[34px] items-center justify-center rounded-full border-2 border-white bg-green-30 text-white sm:h-[38px] sm:w-[38px]'>{mockUser.profileImageUrl}</span>
-              <span className='hidden text-[16px] md:block'>{mockUser.nickname}</span>
-            </button>
-          )}
-        </>
+        <div className='flex items-center gap-[16px] border-r border-gray-30 pr-[12px] sm:gap-[32px] sm:pr-[24px] md:gap-[40px] md:pr-[32px]'>
+          {showSetting && <SettingBtn onSettingClick={handleSettingClick} onInviteClick={handleInviteClick} />}
+          {showMembers && <Members users={mockUsers} />}
+        </div>
+        {showProfile && <Profile nickname={mockUsers[0].nickname} profileImageUrl={mockUsers[0].profileImageUrl} onClick={handleProfileClick} />}
       </div>
     </header>
   );

--- a/src/components/dashboard-header/Header.tsx
+++ b/src/components/dashboard-header/Header.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { usePathname } from 'next/navigation';
 import Image from 'next/image';
 import Crown from '@/assets/icons/crown.svg';
 import Title from './Title';
@@ -14,6 +15,11 @@ interface HeaderProps {
   showProfile?: boolean;
 }
 
+const titleMap: { [key: string]: string } = {
+  '/mydashboard': '내 대시보드',
+  '/mypage': '계정관리',
+};
+
 // API 연동 이후 추가 작업 예정, 우선 mock 데이터로 집어넣어놨습니다.
 interface UserType {
   nickname: string;
@@ -25,7 +31,9 @@ const mockUser: UserType = {
   profileImageUrl: 'B',
 };
 
-export default function Header({ title, showCrown = false, showSetting = false, showUsers = false, showProfile = false }: HeaderProps) {
+export default function Header({ showCrown = false, showSetting = false, showUsers = false, showProfile = false }: HeaderProps) {
+  const pathname = usePathname();
+  const title = titleMap[pathname] || '내 대시보드';
   const handleSettingClick = () => {
     console.log('관리 버튼 클릭');
   };

--- a/src/components/dashboard-header/Members.tsx
+++ b/src/components/dashboard-header/Members.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+interface MembersProps {
+  users: { profileImageUrl: string }[];
+}
+
+export default function Members({ users }: MembersProps) {
+  return (
+    <div className='flex'>
+      {users.map((user, index) => (
+        <span key={index} className='-ml-[8px] flex h-[34px] w-[34px] items-center justify-center rounded-full border-2 border-white bg-green-30 text-white sm:h-[38px] sm:w-[38px]'>
+          {user.profileImageUrl}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/src/components/dashboard-header/Profile.tsx
+++ b/src/components/dashboard-header/Profile.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+interface ProfileProps {
+  nickname: string;
+  profileImageUrl: string;
+  onClick: () => void;
+}
+
+export default function Profile({ nickname, profileImageUrl, onClick }: ProfileProps) {
+  return (
+    <button onClick={onClick} className='mr-[40px] flex items-center justify-center gap-[12px] pl-[12px] sm:pl-[24px] md:pl-[32px]'>
+      <span className='flex h-[34px] w-[34px] items-center justify-center rounded-full border-2 border-white bg-green-30 text-white sm:h-[38px] sm:w-[38px]'>{profileImageUrl}</span>
+      <span className='hidden text-[16px] md:block'>{nickname}</span>
+    </button>
+  );
+}

--- a/src/components/dashboard-header/SettingBtn.tsx
+++ b/src/components/dashboard-header/SettingBtn.tsx
@@ -15,14 +15,14 @@ export default function SettingBtn({ onSettingClick, onInviteClick }: SettingBtn
         className='flex h-[30px] w-[49px] items-center justify-center gap-[8px] rounded-[8px] border border-gray-30 text-[14px] text-gray-50 transition-transform hover:scale-105 hover:border-violet-20 hover:bg-violet-20 hover:text-white sm:h-[40px] sm:w-[88px] md:text-[16px]'
         onClick={onSettingClick}
       >
-        <Image src={Setting} alt='관리 버튼' className='hidden sm:block' />
+        <Image src={Setting} alt='관리 버튼' width={15} height={15} className='hidden sm:block' />
         관리
       </button>
       <button
         className='flex h-[30px] w-[73px] items-center justify-center gap-[8px] rounded-[8px] border border-gray-30 text-[14px] text-gray-50 transition-transform hover:scale-105 hover:border-violet-20 hover:bg-violet-20 hover:text-white sm:h-[40px] sm:w-[116px] md:text-[14px]'
         onClick={onInviteClick}
       >
-        <Image src={AddBox} alt='초대 버튼' className='hidden sm:block' />
+        <Image src={AddBox} alt='초대 버튼' width={15} height={15} className='hidden sm:block' />
         초대하기
       </button>
     </div>

--- a/src/components/dashboard-header/SettingBtn.tsx
+++ b/src/components/dashboard-header/SettingBtn.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import Image from 'next/image';
+import Setting from '@/assets/icons/setting.svg';
+import AddBox from '@/assets/icons/add_box.svg';
+
+interface SettingBtnProps {
+  onSettingClick: () => void;
+  onInviteClick: () => void;
+}
+
+export default function SettingBtn({ onSettingClick, onInviteClick }: SettingBtnProps) {
+  return (
+    <div className='flex items-center gap-[6px] sm:gap-[12px] md:gap-[16px]'>
+      <button
+        className='flex h-[30px] w-[49px] items-center justify-center gap-[8px] rounded-[8px] border border-gray-30 text-[14px] text-gray-50 transition-transform hover:scale-105 hover:border-violet-20 hover:bg-violet-20 hover:text-white sm:h-[40px] sm:w-[88px] md:text-[16px]'
+        onClick={onSettingClick}
+      >
+        <Image src={Setting} alt='관리 버튼' className='hidden sm:block' />
+        관리
+      </button>
+      <button
+        className='flex h-[30px] w-[73px] items-center justify-center gap-[8px] rounded-[8px] border border-gray-30 text-[14px] text-gray-50 transition-transform hover:scale-105 hover:border-violet-20 hover:bg-violet-20 hover:text-white sm:h-[40px] sm:w-[116px] md:text-[14px]'
+        onClick={onInviteClick}
+      >
+        <Image src={AddBox} alt='초대 버튼' className='hidden sm:block' />
+        초대하기
+      </button>
+    </div>
+  );
+}

--- a/src/components/dashboard-header/Title.tsx
+++ b/src/components/dashboard-header/Title.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+interface TitleProps {
+  title?: string;
+}
+
+export default function Title({ title }: TitleProps) {
+  return (
+    <div className='flex items-center'>
+      <span className='hidden text-[20px] font-bold lg:block'>{title}</span>
+    </div>
+  );
+}


### PR DESCRIPTION
## ❓이슈
- close #13 

## :writing_hand: Description


대시보드 공용 헤더 컴포넌트 구현하여 PR 올립니다.

**작업 사항**
- 대시보드 헤더 컴포넌트 구현
- 반응형 구현
- 컴포넌트 라우터에 따라 title이 변경되도록 구현
- 성락님께서 만드신 임시 mydashboard에 추가해놨습니다.

우선 API연동 작업 전까지 mock데이터로 멤버아이콘과 사용자 프로필을 설정해놨습니다.
반응형이 아직 어색한 부분이 많아 추후 추가 작업을 진행하도록 하겠습니다.
사이드바와 합쳐지니 스타일이 조금 어색한 부분이 있습니다. 이것도 추가로 수정하도록 하겠습니다.


![image](https://github.com/user-attachments/assets/a6e9ad9e-becb-46a2-a081-f07914efd07f)
![image](https://github.com/user-attachments/assets/fbc4653f-9826-47ba-92fe-cfe07815a080)
![image](https://github.com/user-attachments/assets/c1eaf1fa-75fb-4e0d-a649-346be5401ffb)


## :white_check_mark: Checklist

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] Image 컴포넌트 width, height prop 수정
- [x] 주석 내용 -> TODO로 수정
- [x] 컴포넌트 세분화
