### PR TITLE
Feat/34/modal

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,13 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer base {
+  .safe-center {
+    display:flex;
+    align-items: safe center;
+    justify-content: safe center;
+  }
+}
 
 :root {
   --font-pretendard: 'Pretendard', sans-serif;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import localFont from 'next/font/local';
 import { Montserrat } from 'next/font/google';
+import { DialogContainer } from '@/components/ui/Modal/DialogContainer';
 import './globals.css';
 
 const pretendard = localFont({
@@ -22,7 +23,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang='ko'>
-      <body className={`${pretendard.className} ${montserrat.variable}`}>{children}</body>
+      <body className={`${pretendard.className} ${montserrat.variable}`}>
+        {children}
+        <DialogContainer />
+      </body>
     </html>
   );
 }

--- a/src/components/ui/Modal/BaseModal.tsx
+++ b/src/components/ui/Modal/BaseModal.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { MouseEvent, PropsWithChildren } from 'react';
+import { createPortal } from 'react-dom';
+import { motion } from 'motion/react';
+
+interface BaseModalProps {
+  isOpen: boolean;
+  onClose?: () => void;
+}
+
+const overlay = {
+  hidden: { opacity: 0 },
+  show: { opacity: 1 },
+};
+
+const container = {
+  hidden: { opacity: 0, y: -20 },
+  show: { opacity: 1, y: 0 },
+};
+
+export default function BaseModal({ isOpen, onClose, children }: PropsWithChildren<BaseModalProps>) {
+  if (!isOpen) return null;
+
+  const handleDimClick = (e: MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      onClose?.();
+    }
+  };
+
+  return createPortal(
+    <motion.div variants={overlay} initial='hidden' animate='show' className='safe-center fixed bottom-0 left-0 right-0 top-0 z-50 overflow-y-auto bg-black/20 p-8' onClick={handleDimClick}>
+      <motion.div variants={container}>{children}</motion.div>
+    </motion.div>,
+    document.body!,
+  );
+}

--- a/src/components/ui/Modal/DialogContainer.tsx
+++ b/src/components/ui/Modal/DialogContainer.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useDialogStore } from '@/stores/modalStore';
+import BaseModal from './BaseModal';
+import Button from '../Button/Button';
+
+export function DialogContainer() {
+  const { isOpen, message, callback, closeDialog } = useDialogStore();
+
+  const handleConfirm = () => {
+    callback?.();
+    closeDialog();
+  };
+
+  return (
+    <BaseModal isOpen={isOpen}>
+      <div className='w-dvw max-w-[272px] rounded-lg bg-white px-4 py-6 md:max-w-[368px] md:px-6'>
+        <div className='break-keep text-center text-xl font-medium'>{message}</div>
+        <div className='mt-10 flex justify-center gap-2'>
+          <Button size='sm' onClick={handleConfirm}>
+            확인
+          </Button>
+        </div>
+      </div>
+    </BaseModal>
+  );
+}

--- a/src/components/ui/Modal/Modal.tsx
+++ b/src/components/ui/Modal/Modal.tsx
@@ -14,8 +14,8 @@ import { cn } from '@/utils/helper';
  * modalRef.current.close() // 모달닫기
  *
  * <Modal ref={modalRef}>
- *   <ModalHeader>제목</ModalHeader>
- *   <ModalContent>
+ *   <ModalContent> // 하얀색 배경카드 (꼭 있어야합니다.)
+ *     <ModalHeader>제목</ModalHeader>
  *     <div>내용</div>
  *     <ModalFooter>버튼들</ModalFooter> // flex 배치됨
  *   </ModalContent>

--- a/src/components/ui/Modal/Modal.tsx
+++ b/src/components/ui/Modal/Modal.tsx
@@ -1,0 +1,52 @@
+import { forwardRef, HTMLAttributes, PropsWithChildren, useImperativeHandle, useState } from 'react';
+import BaseModal from './BaseModal';
+import { cn } from '@/utils/helper';
+
+export type ModalHandle = {
+  open: () => void;
+  close: () => void;
+};
+
+export const Modal = forwardRef<ModalHandle, PropsWithChildren>((props, ref) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  useImperativeHandle(ref, () => {
+    return {
+      open() {
+        setIsOpen(true);
+      },
+      close() {
+        setIsOpen(false);
+      },
+    };
+  });
+
+  return <BaseModal isOpen={isOpen} onClose={() => setIsOpen(false)} {...props} />;
+});
+
+export function ModalHeader({ children, className, ...props }: PropsWithChildren<HTMLAttributes<HTMLDivElement>>) {
+  return (
+    <header className={cn('mb-4 flex h-9 items-center justify-between text-xl font-bold md:text-2xl', className)} {...props}>
+      {children}
+    </header>
+  );
+}
+
+export function ModalContent({ children, className, ...props }: PropsWithChildren<HTMLAttributes<HTMLDivElement>>) {
+  return (
+    <div className={cn('w-dvw max-w-[327px] rounded-lg bg-white px-4 py-6 md:max-w-[584px] md:px-6', className)} {...props}>
+      {children}
+    </div>
+  );
+}
+
+export function ModalFooter({ children, className, ...props }: PropsWithChildren<HTMLAttributes<HTMLDivElement>>) {
+  return (
+    <footer className={cn('mt-6 flex gap-2', className)} {...props}>
+      {children}
+    </footer>
+  );
+}
+
+// eslintreact/display-name (forwardref)
+Modal.displayName = 'Modal';

--- a/src/components/ui/Modal/Modal.tsx
+++ b/src/components/ui/Modal/Modal.tsx
@@ -2,6 +2,29 @@ import { forwardRef, HTMLAttributes, PropsWithChildren, useImperativeHandle, use
 import BaseModal from './BaseModal';
 import { cn } from '@/utils/helper';
 
+/**
+ * Modal 컴포넌트 (컨텐츠 주입형)
+ * 모달을 생성하고 외부에서 열고 닫을 수 있는 제어를 제공
+ *
+ * @example
+ *
+ * const modalRef = useRef<ModalHandle>(null);
+ *
+ * modalRef.current.open()  // 모달열기
+ * modalRef.current.close() // 모달닫기
+ *
+ * <Modal ref={modalRef}>
+ *   <ModalHeader>제목</ModalHeader>
+ *   <ModalContent>
+ *     <div>내용</div>
+ *     <ModalFooter>버튼들</ModalFooter> // flex 배치됨
+ *   </ModalContent>
+ * </Modal>
+ *
+ * Modal내부의 컴포넌트들은 Compound 형태로, 컴포넌트를 필요에따라 넣으면됩니다.
+ * 예) 상단제목이 없는 모달을 만들때는 ModalHeader를 빼면 됩니다.
+ */
+
 export type ModalHandle = {
   open: () => void;
   close: () => void;

--- a/src/hooks/useAlert.ts
+++ b/src/hooks/useAlert.ts
@@ -1,0 +1,11 @@
+import { useDialogStore } from '@/stores/modalStore';
+
+export default function useAlert() {
+  const { openDialog } = useDialogStore();
+
+  const alert = (message: string, callback?: () => void) => {
+    openDialog({ message, callback });
+  };
+
+  return alert;
+}

--- a/src/hooks/useAlert.ts
+++ b/src/hooks/useAlert.ts
@@ -1,5 +1,26 @@
 import { useDialogStore } from '@/stores/modalStore';
 
+/**
+ * useAlert 훅
+ *
+ * 간단한 메시지 노출과 선택적 콜백을 실행해주는 알럿 다이얼로그
+ *
+ * @example
+ * import useAlert from '@/hooks/useAlert';
+ *
+ * function Component() {
+ *   const alert = useAlert();
+ *
+ *   const handleClick = () => {
+ *     alert('메시지 표시', () => {
+ *       console.log('다이얼로그가 닫힌후 콜백입니다. 생략 가능합니다.');
+ *     });
+ *   };
+ *
+ *   return <button onClick={handleClick}>알림 표시</button>;
+ * }
+ */
+
 export default function useAlert() {
   const { openDialog } = useDialogStore();
 

--- a/src/stores/modalStore.ts
+++ b/src/stores/modalStore.ts
@@ -1,0 +1,19 @@
+import { create } from 'zustand';
+
+type DialogState = {
+  isOpen: boolean;
+  message: string;
+  callback?: () => void;
+
+  openDialog: ({ message, callback }: { message: string; callback?: () => void }) => void;
+  closeDialog: () => void;
+};
+
+export const useDialogStore = create<DialogState>()((set) => ({
+  isOpen: false,
+  message: '',
+  callback: undefined,
+
+  openDialog: ({ message, callback }) => set({ isOpen: true, message, callback }),
+  closeDialog: () => set({ isOpen: false, message: '', callback: undefined }),
+}));


### PR DESCRIPTION
## ❓이슈
- close #34 

## :writing_hand: Description
<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->

공용 모달 컴포넌트 작업했습니다.
- base modal component 작업 (기본 베이스)
- useAlert 훅을 통해 생성되는 알럿 모달 작업
  - zustand로 dialog store를 생성
  - useAlert을 통해 alert을 실행하면 루트 레이아웃에 있는 다이알로그 컨테이너 안에서 모달이 열림
  
- 페이지내에서 사용되는 공용 모달 컴포넌트 작업
  - useImeprativeHandle 훅을 통해서 모달외부에서 제어를 할 수 있도록 함
  - 공용 모달 컴포넌트 안쪽에 compound 형태로 내부 컴포넌트를 제공  

**추가전달**
- 사용방법을 주석으로 남겨두었습니다.
- 사용하면서 불편하거나, 개선해볼점을 알게 되면 또 리팩토링 해보겠습니다.


<img width="1703" alt="스크린샷 2025-02-06 오후 9 47 26" src="https://github.com/user-attachments/assets/cc94ab23-ef97-455b-90a6-f633dbc2b456" />

## :white_check_mark: Checklist

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
