### PR TITLE
Feat/29/field components

### DIFF
--- a/src/app/(dashboard)/form/page.tsx
+++ b/src/app/(dashboard)/form/page.tsx
@@ -86,7 +86,7 @@ export default function FormPage() {
           <SearchInput placeholder='검색어를 입력해주세요' />
         </div>
         <form onSubmit={handleSubmit(onSubmit)} className='grid gap-4'>
-          {/*  */}
+          {/* input sample : uncontrolled  */}
           <Input //
             label='제목'
             error={errors.title?.message}

--- a/src/app/(dashboard)/form/page.tsx
+++ b/src/app/(dashboard)/form/page.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Controller, useForm } from 'react-hook-form';
+import { z } from 'zod';
+import Button from '@/components/ui/Button/Button';
+import { Input, Textarea, TagInput, DateInput, ImageUpload, SearchInput } from '@/components/ui/Field';
+
+/**
+ * Input, Textarea, SearchInput 컴포넌트는 controlled, uncontrolled 둘다 사용하실 수 있습니다.
+ * TagInput, DateInput, ImageUpload는 controlled로만 작동합니다.
+ *
+ * controlled 컴포넌트를 RHF(React Hook Form)에 연결하는 샘플은
+ * 아래 코드에서 확인하시면 됩니다.
+ * (RHF의 Controller의 render함수에서 제공하는 field(value, onChange, onBlur)를
+ * 내부 컴포넌트에게 전달해서 작동을 하는 원리입니다.)
+ *
+ *
+ * 커스텀 컴포넌트를 제외한 대부분의 컴포넌트는 기본적으로 input attributes를 확장하여 제공하도록 작성하여
+ * 기본 input의 속성들을 전달하실 수 있습니다. (placeholder, required, disabled, readonly....)
+ */
+
+const sampleSchema = z.object({
+  title: z.string().min(2, { message: '최소 두글자 이상 작성해주세요' }),
+  content: z.string().min(2, { message: '최소 두글자 이상 작성해주세요' }),
+  date: z.date({ message: '날짜를 입력해주세요' }),
+  tags: z.array(z.string()).min(1, { message: '태그를 한개 이상 입력해주세요.' }),
+  keyword: z.string(),
+  image: z
+    .union([
+      z
+        .instanceof(File)
+        .refine((file) => file.type.startsWith('image/'), { message: '이미지 파일만 업로드 가능합니다.' })
+        .refine((file) => file.size < 2 * 1024 * 1024, { message: '2MB이하로 올려주세요' }),
+      z.string(),
+    ])
+    .optional(),
+  // 파일업로드를 필수로 하려면 optional을 지우고 아래 refine을 붙여주시면됩니다.
+  // .refine((value) => value instanceof File || (typeof value === 'string' && value.length > 0), { message: '파일을 업로드해주세요' }),
+});
+
+type SampleFormType = z.infer<typeof sampleSchema>;
+
+export default function FormPage() {
+  const {
+    register,
+    control,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<SampleFormType>({
+    resolver: zodResolver(sampleSchema),
+    mode: 'onBlur',
+    defaultValues: {
+      title: '제목',
+      content: '내용내용 테스트세트슽',
+      date: undefined,
+      tags: [],
+      keyword: '',
+      image: undefined,
+    },
+  });
+
+  const onSubmit = (formData: SampleFormType) => {
+    console.log(formData);
+  };
+
+  return (
+    <div className='p-10'>
+      <div className='rounded-md bg-white p-10'>
+        <div className='mb-10 grid gap-3'>
+          {/* input sample : controlled */}
+          <Input
+            value='readonly 설정을 하면 글자만 조금 투명해집니다.'
+            onChange={(e) => {
+              console.log(e.target.value);
+            }}
+            readOnly
+          />
+          <Textarea
+            value='disabled 설정하면 배경도 어두워집니다.'
+            onChange={(e) => {
+              console.log(e.target.value);
+            }}
+            disabled
+          />
+          <SearchInput placeholder='검색어를 입력해주세요' />
+        </div>
+        <form onSubmit={handleSubmit(onSubmit)} className='grid gap-4'>
+          {/*  */}
+          <Input //
+            label='제목'
+            error={errors.title?.message}
+            placeholder='제목을 입력해주세요'
+            required
+            {...register('title')}
+          />
+
+          {/* textarea sample : uncontrolled */}
+          <Textarea //
+            label='내용'
+            error={errors.content?.message}
+            placeholder='내용을 입력해주세요'
+            required
+            {...register('content')}
+          />
+
+          {/* datepicker sample : controlled */}
+          <Controller //
+            name='date'
+            control={control}
+            render={({ field }) => {
+              return (
+                <DateInput //
+                  label='마감일'
+                  error={errors.date?.message}
+                  placeholder='날짜를 입력해주세요'
+                  required
+                  {...field}
+                  readOnly
+                />
+              );
+            }}
+          />
+
+          {/* tags input sample : controlled */}
+          <Controller //
+            name='tags'
+            control={control}
+            render={({ field }) => {
+              return (
+                <TagInput //
+                  label='태그'
+                  error={errors.tags?.message}
+                  placeholder='입력후 Enter'
+                  required
+                  {...field}
+                />
+              );
+            }}
+          />
+
+          {/* image upload sample : controlled */}
+          <Controller
+            name='image'
+            control={control}
+            render={({ field }) => {
+              return (
+                <ImageUpload //
+                  label='이미지'
+                  error={errors.image?.message}
+                  {...field}
+                />
+              );
+            }}
+          />
+
+          <Button type='submit'>제출</Button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/form/page.tsx
+++ b/src/app/(dashboard)/form/page.tsx
@@ -116,7 +116,6 @@ export default function FormPage() {
                   placeholder='날짜를 입력해주세요'
                   required
                   {...field}
-                  readOnly
                 />
               );
             }}

--- a/src/assets/icons/x_white.svg
+++ b/src/assets/icons/x_white.svg
@@ -1,0 +1,4 @@
+<svg width="10" height="10" viewBox="0 0 10 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="2.17163" y="0.757812" width="10" height="2" transform="rotate(45 2.17163 0.757812)" fill="white"/>
+<rect x="9.24268" y="2.17188" width="10" height="2" transform="rotate(135 9.24268 2.17188)" fill="white"/>
+</svg>

--- a/src/components/ui/Field/Base.tsx
+++ b/src/components/ui/Field/Base.tsx
@@ -1,0 +1,21 @@
+import { PropsWithChildren } from 'react';
+
+export function BaseItem({ children }: PropsWithChildren) {
+  return <div className='grid gap-2'>{children}</div>;
+}
+
+export function BaseLabel({ required, children }: PropsWithChildren<{ required?: boolean }>) {
+  return (
+    <label className='inline-flex items-center gap-[2px] text-md font-medium md:text-2lg'>
+      {children}
+      {required && <span className='pt-[2px] text-violet-20'>*</span>}
+    </label>
+  );
+}
+
+export function BaseError({ children }: PropsWithChildren) {
+  return <div className='text-md text-red'>{children}</div>;
+}
+
+export const baseFieldClassName = 'border h-[50px] rounded-lg w-full p-4 text-md focus-visible:outline-none md:text-lg read-only:text-gray-40';
+export const baseErrorClassName = 'border-red';

--- a/src/components/ui/Field/Base.tsx
+++ b/src/components/ui/Field/Base.tsx
@@ -1,12 +1,12 @@
-import { PropsWithChildren } from 'react';
+import { LabelHTMLAttributes, PropsWithChildren } from 'react';
 
 export function BaseItem({ children }: PropsWithChildren) {
   return <div className='grid gap-2'>{children}</div>;
 }
 
-export function BaseLabel({ required, children }: PropsWithChildren<{ required?: boolean }>) {
+export function BaseLabel({ required, children, ...props }: PropsWithChildren<LabelHTMLAttributes<HTMLLabelElement> & { required?: boolean }>) {
   return (
-    <label className='inline-flex items-center gap-[2px] text-md font-medium md:text-2lg'>
+    <label className='inline-flex items-center gap-[2px] text-md font-medium md:text-2lg' {...props}>
       {children}
       {required && <span className='pt-[2px] text-violet-20'>*</span>}
     </label>

--- a/src/components/ui/Field/DateInput.tsx
+++ b/src/components/ui/Field/DateInput.tsx
@@ -1,4 +1,4 @@
-import { InputHTMLAttributes } from 'react';
+import { InputHTMLAttributes, useId } from 'react';
 import Image from 'next/image';
 import DatePicker from 'react-datepicker';
 import { cn } from '@/utils/helper';
@@ -14,12 +14,19 @@ type DateInputProps = BaseField &
   };
 
 export function DateInput({ label, error, value, onChange, onBlur, placeholder, required, className, disabled, readOnly }: DateInputProps) {
+  const id = useId();
+
   return (
     <BaseItem>
-      {label && <BaseLabel required={required}>{label}</BaseLabel>}
+      {label && (
+        <BaseLabel required={required} htmlFor={id}>
+          {label}
+        </BaseLabel>
+      )}
       <div className='relative grid'>
         <Image src={calendarIcon} alt='날짜선택' className={cn('pointer-events-none absolute left-4 top-1/2 z-20 h-auto w-4 -translate-y-1/2 opacity-50', value && 'opacity-100')} />
         <DatePicker //
+          id={id}
           selected={value}
           onChange={onChange}
           onBlur={onBlur}

--- a/src/components/ui/Field/DateInput.tsx
+++ b/src/components/ui/Field/DateInput.tsx
@@ -13,7 +13,7 @@ type DateInputProps = BaseField &
     onChange: (value: Date | null) => void;
   };
 
-export function DateInput({ label, error, value, onChange, onBlur, placeholder, required, className }: DateInputProps) {
+export function DateInput({ label, error, value, onChange, onBlur, placeholder, required, className, disabled, readOnly }: DateInputProps) {
   return (
     <BaseItem>
       {label && <BaseLabel required={required}>{label}</BaseLabel>}
@@ -26,6 +26,8 @@ export function DateInput({ label, error, value, onChange, onBlur, placeholder, 
           className={cn(baseFieldClassName, 'p-4 pl-10', error && baseErrorClassName, className)}
           dateFormat='yyyy년 MM월 dd일'
           placeholderText={placeholder}
+          disabled={disabled}
+          readOnly={readOnly}
         />
       </div>
       {error && <BaseError>{error}</BaseError>}

--- a/src/components/ui/Field/DateInput.tsx
+++ b/src/components/ui/Field/DateInput.tsx
@@ -1,0 +1,34 @@
+import { InputHTMLAttributes } from 'react';
+import Image from 'next/image';
+import DatePicker from 'react-datepicker';
+import { cn } from '@/utils/helper';
+import { BaseError, baseErrorClassName, baseFieldClassName, BaseItem, BaseLabel } from './Base';
+import calendarIcon from '@/assets/icons/calendar.svg';
+import { BaseField } from './types';
+import 'react-datepicker/dist/react-datepicker.css';
+
+type DateInputProps = BaseField &
+  Omit<InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange'> & {
+    value: Date;
+    onChange: (value: Date | null) => void;
+  };
+
+export function DateInput({ label, error, value, onChange, onBlur, placeholder, required, className }: DateInputProps) {
+  return (
+    <BaseItem>
+      {label && <BaseLabel required={required}>{label}</BaseLabel>}
+      <div className='relative grid'>
+        <Image src={calendarIcon} alt='날짜선택' className={cn('pointer-events-none absolute left-4 top-1/2 z-20 h-auto w-4 -translate-y-1/2 opacity-50', value && 'opacity-100')} />
+        <DatePicker //
+          selected={value}
+          onChange={onChange}
+          onBlur={onBlur}
+          className={cn(baseFieldClassName, 'p-4 pl-10', error && baseErrorClassName, className)}
+          dateFormat='yyyy년 MM월 dd일'
+          placeholderText={placeholder}
+        />
+      </div>
+      {error && <BaseError>{error}</BaseError>}
+    </BaseItem>
+  );
+}

--- a/src/components/ui/Field/ImageUpload.tsx
+++ b/src/components/ui/Field/ImageUpload.tsx
@@ -1,0 +1,64 @@
+import { ChangeEvent, InputHTMLAttributes, useEffect, useRef } from 'react';
+import Image from 'next/image';
+import { BaseError, BaseItem, BaseLabel } from './Base';
+import { BaseField } from './types';
+import deleteIcon from '@/assets/icons/x_white.svg';
+import addIcon from '@/assets/icons/plus.svg';
+
+type ImageUploadProps = BaseField &
+  Omit<InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange' | 'onBlur'> & {
+    value: File | string | undefined;
+    onChange: (file: File | undefined) => void;
+    onBlur: () => void;
+  };
+
+export function ImageUpload({ value, onChange, onBlur, label, required, error }: ImageUploadProps) {
+  const preview = value instanceof File ? URL.createObjectURL(value) : value;
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    return () => {
+      if (preview && value instanceof File) {
+        URL.revokeObjectURL(preview);
+      }
+    };
+  }, [preview, value]);
+
+  function handleChange(e: ChangeEvent<HTMLInputElement>) {
+    if (!e.target.files) return;
+
+    const files = e.target.files;
+    onChange(files[0]);
+    onBlur();
+
+    if (fileRef.current) {
+      fileRef.current.value = '';
+    }
+  }
+
+  function handleRemove() {
+    if (fileRef.current) {
+      fileRef.current.value = '';
+    }
+
+    onChange(undefined);
+  }
+
+  return (
+    <BaseItem>
+      {label && <BaseLabel required={required}>{label}</BaseLabel>}
+      <div className='relative aspect-square w-[76px]'>
+        <label className='relative flex h-full w-full cursor-pointer items-center justify-center overflow-hidden rounded-md bg-gray-10'>
+          {preview ? <Image src={preview} alt='thumbnail' fill sizes='40vw' className='absolute h-full w-full object-cover' /> : <Image src={addIcon} alt='업로드' />}
+          <input type='file' accept='image/*' ref={fileRef} onChange={handleChange} className='sr-only' />
+        </label>
+        {preview && (
+          <button type='button' className='absolute -right-1 -top-1 flex h-5 w-5 cursor-pointer items-center justify-center rounded-full bg-black' onClick={handleRemove}>
+            <Image src={deleteIcon} alt='삭제' />
+          </button>
+        )}
+      </div>
+      {error && <BaseError>{error}</BaseError>}
+    </BaseItem>
+  );
+}

--- a/src/components/ui/Field/ImageUpload.tsx
+++ b/src/components/ui/Field/ImageUpload.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, InputHTMLAttributes, useEffect, useRef } from 'react';
+import { ChangeEvent, InputHTMLAttributes, useEffect, useId, useRef } from 'react';
 import Image from 'next/image';
 import { cn } from '@/utils/helper';
 import { BaseError, BaseItem, BaseLabel } from './Base';
@@ -16,6 +16,7 @@ type ImageUploadProps = BaseField &
 export function ImageUpload({ value, onChange, onBlur, label, required, error, className }: ImageUploadProps) {
   const preview = value instanceof File ? URL.createObjectURL(value) : value;
   const fileRef = useRef<HTMLInputElement>(null);
+  const id = useId();
 
   useEffect(() => {
     return () => {
@@ -47,11 +48,15 @@ export function ImageUpload({ value, onChange, onBlur, label, required, error, c
 
   return (
     <BaseItem>
-      {label && <BaseLabel required={required}>{label}</BaseLabel>}
+      {label && (
+        <BaseLabel required={required} htmlFor={id}>
+          {label}
+        </BaseLabel>
+      )}
       <div className={cn('relative aspect-square w-[76px]', className)}>
         <label className='relative flex h-full w-full cursor-pointer items-center justify-center overflow-hidden rounded-md bg-gray-10'>
           {preview ? <Image src={preview} alt='thumbnail' fill sizes='40vw' className='absolute h-full w-full object-cover' /> : <Image src={addIcon} className='h-auto w-[18px]' alt='업로드' />}
-          <input type='file' accept='image/*' ref={fileRef} onChange={handleChange} className='sr-only' />
+          <input id={id} type='file' accept='image/*' ref={fileRef} onChange={handleChange} className='sr-only' />
         </label>
         {preview && (
           <button type='button' className='absolute -right-1 -top-1 flex h-5 w-5 cursor-pointer items-center justify-center rounded-full bg-black' onClick={handleRemove}>

--- a/src/components/ui/Field/ImageUpload.tsx
+++ b/src/components/ui/Field/ImageUpload.tsx
@@ -1,5 +1,6 @@
 import { ChangeEvent, InputHTMLAttributes, useEffect, useRef } from 'react';
 import Image from 'next/image';
+import { cn } from '@/utils/helper';
 import { BaseError, BaseItem, BaseLabel } from './Base';
 import { BaseField } from './types';
 import deleteIcon from '@/assets/icons/x_white.svg';
@@ -12,7 +13,7 @@ type ImageUploadProps = BaseField &
     onBlur: () => void;
   };
 
-export function ImageUpload({ value, onChange, onBlur, label, required, error }: ImageUploadProps) {
+export function ImageUpload({ value, onChange, onBlur, label, required, error, className }: ImageUploadProps) {
   const preview = value instanceof File ? URL.createObjectURL(value) : value;
   const fileRef = useRef<HTMLInputElement>(null);
 
@@ -47,9 +48,9 @@ export function ImageUpload({ value, onChange, onBlur, label, required, error }:
   return (
     <BaseItem>
       {label && <BaseLabel required={required}>{label}</BaseLabel>}
-      <div className='relative aspect-square w-[76px]'>
+      <div className={cn('relative aspect-square w-[76px]', className)}>
         <label className='relative flex h-full w-full cursor-pointer items-center justify-center overflow-hidden rounded-md bg-gray-10'>
-          {preview ? <Image src={preview} alt='thumbnail' fill sizes='40vw' className='absolute h-full w-full object-cover' /> : <Image src={addIcon} alt='업로드' />}
+          {preview ? <Image src={preview} alt='thumbnail' fill sizes='40vw' className='absolute h-full w-full object-cover' /> : <Image src={addIcon} className='h-auto w-[18px]' alt='업로드' />}
           <input type='file' accept='image/*' ref={fileRef} onChange={handleChange} className='sr-only' />
         </label>
         {preview && (

--- a/src/components/ui/Field/Input.tsx
+++ b/src/components/ui/Field/Input.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, InputHTMLAttributes } from 'react';
+import { forwardRef, InputHTMLAttributes, useId } from 'react';
 import { cn } from '@/utils/helper';
 import { BaseError, baseErrorClassName, baseFieldClassName, BaseItem, BaseLabel } from './Base';
 import { BaseField } from './types';
@@ -6,10 +6,16 @@ import { BaseField } from './types';
 type InputProps = BaseField & InputHTMLAttributes<HTMLInputElement>;
 
 export const Input = forwardRef<HTMLInputElement, InputProps>(({ label, error, className, ...props }, ref) => {
+  const id = useId();
+
   return (
     <BaseItem>
-      {label && <BaseLabel required={props.required}>{label}</BaseLabel>}
-      <input {...props} className={cn(baseFieldClassName, error && baseErrorClassName, className)} ref={ref} />
+      {label && (
+        <BaseLabel required={props.required} htmlFor={id}>
+          {label}
+        </BaseLabel>
+      )}
+      <input id={id} {...props} className={cn(baseFieldClassName, error && baseErrorClassName, className)} ref={ref} />
       {error && <BaseError>{error}</BaseError>}
     </BaseItem>
   );

--- a/src/components/ui/Field/Input.tsx
+++ b/src/components/ui/Field/Input.tsx
@@ -1,0 +1,18 @@
+import { forwardRef, InputHTMLAttributes } from 'react';
+import { cn } from '@/utils/helper';
+import { BaseError, baseErrorClassName, baseFieldClassName, BaseItem, BaseLabel } from './Base';
+import { BaseField } from './types';
+
+type InputProps = BaseField & InputHTMLAttributes<HTMLInputElement>;
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(({ label, error, className, ...props }, ref) => {
+  return (
+    <BaseItem>
+      {label && <BaseLabel required={props.required}>{label}</BaseLabel>}
+      <input {...props} className={cn(baseFieldClassName, error && baseErrorClassName, className)} ref={ref} />
+      {error && <BaseError>{error}</BaseError>}
+    </BaseItem>
+  );
+});
+
+Input.displayName = 'Input';

--- a/src/components/ui/Field/SearchInput.tsx
+++ b/src/components/ui/Field/SearchInput.tsx
@@ -1,0 +1,19 @@
+import { forwardRef, InputHTMLAttributes } from 'react';
+import Image from 'next/image';
+import { cn } from '@/utils/helper';
+import { baseFieldClassName } from './Base';
+import { BaseField } from './types';
+import searchIcon from '@/assets/icons/search.svg';
+
+type SearchInputProps = BaseField & InputHTMLAttributes<HTMLInputElement>;
+
+export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(({ className, ...props }, ref) => {
+  return (
+    <div className='relative'>
+      <input {...props} className={cn(baseFieldClassName, 'pl-10', className)} ref={ref} />
+      <Image src={searchIcon} className='pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2' alt='search' />
+    </div>
+  );
+});
+
+SearchInput.displayName = 'SearchInput';

--- a/src/components/ui/Field/TagInput.tsx
+++ b/src/components/ui/Field/TagInput.tsx
@@ -1,4 +1,4 @@
-import { FocusEvent, InputHTMLAttributes, KeyboardEvent, useEffect, useRef, useState } from 'react';
+import { FocusEvent, InputHTMLAttributes, KeyboardEvent, useEffect, useId, useRef, useState } from 'react';
 import { motion } from 'motion/react';
 import { cn } from '@/utils/helper';
 import TagChip from '../Chip/TagChip';
@@ -14,6 +14,7 @@ type TagInputProps = BaseField &
 export function TagInput({ label, error, value, onChange, className, placeholder, onBlur, required }: TagInputProps) {
   const [focused, setFocused] = useState(false);
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const id = useId();
 
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.nativeEvent.isComposing) return;
@@ -53,7 +54,11 @@ export function TagInput({ label, error, value, onChange, className, placeholder
 
   return (
     <BaseItem>
-      {label && <BaseLabel required={required}>{label}</BaseLabel>}
+      {label && (
+        <BaseLabel required={required} htmlFor={id}>
+          {label}
+        </BaseLabel>
+      )}
       <div className={cn(baseFieldClassName, 'flex h-auto min-h-[50px] flex-wrap items-center gap-2 px-4 py-2', error && baseErrorClassName, className)} onClick={() => setFocused(true)}>
         {value.map((item) => (
           <motion.div //
@@ -66,6 +71,7 @@ export function TagInput({ label, error, value, onChange, className, placeholder
         ))}
         {(value.length === 0 || focused) && (
           <input //
+            id={id}
             ref={inputRef}
             className='flex flex-1 focus-visible:outline-none'
             onKeyDown={handleKeyDown}

--- a/src/components/ui/Field/TagInput.tsx
+++ b/src/components/ui/Field/TagInput.tsx
@@ -73,7 +73,7 @@ export function TagInput({ label, error, value, onChange, className, placeholder
           <input //
             id={id}
             ref={inputRef}
-            className='flex flex-1 focus-visible:outline-none'
+            className='flex flex-1 text-black focus-visible:outline-none'
             onKeyDown={handleKeyDown}
             onBlur={handleBlur}
             placeholder={placeholder}

--- a/src/components/ui/Field/TagInput.tsx
+++ b/src/components/ui/Field/TagInput.tsx
@@ -1,0 +1,80 @@
+import { FocusEvent, InputHTMLAttributes, KeyboardEvent, useEffect, useRef, useState } from 'react';
+import { motion } from 'motion/react';
+import { cn } from '@/utils/helper';
+import TagChip from '../Chip/TagChip';
+import { BaseError, baseErrorClassName, baseFieldClassName, BaseItem, BaseLabel } from './Base';
+import { BaseField } from './types';
+
+type TagInputProps = BaseField &
+  Omit<InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange'> & {
+    value: string[];
+    onChange: (value: string[]) => void;
+  };
+
+export function TagInput({ label, error, value, onChange, className, placeholder, onBlur, required }: TagInputProps) {
+  const [focused, setFocused] = useState(false);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.nativeEvent.isComposing) return;
+
+    const input = e.currentTarget;
+    const tag = input.value.trim();
+
+    if (e.key === 'Enter') {
+      e.preventDefault();
+
+      if (tag) {
+        const newTags = new Set([...value, tag]);
+        onChange(Array.from(newTags));
+        input.value = '';
+      }
+    }
+
+    if (e.key === 'Backspace' && value.length > 0 && !tag.length) {
+      e.preventDefault();
+
+      const newTags = [...value];
+      newTags.pop();
+      onChange(newTags);
+    }
+  };
+
+  const handleBlur = (e: FocusEvent<HTMLInputElement>) => {
+    onBlur?.(e);
+    setFocused(false);
+  };
+
+  useEffect(() => {
+    if (focused) {
+      inputRef.current?.focus();
+    }
+  }, [focused]);
+
+  return (
+    <BaseItem>
+      {label && <BaseLabel required={required}>{label}</BaseLabel>}
+      <div className={cn(baseFieldClassName, 'flex h-auto min-h-[50px] flex-wrap items-center gap-2 px-4 py-2', error && baseErrorClassName, className)} onClick={() => setFocused(true)}>
+        {value.map((item) => (
+          <motion.div //
+            key={item}
+            animate={{ scale: 1 }}
+            initial={{ scale: 0 }}
+          >
+            <TagChip label={item} />
+          </motion.div>
+        ))}
+        {(value.length === 0 || focused) && (
+          <input //
+            ref={inputRef}
+            className='flex flex-1 focus-visible:outline-none'
+            onKeyDown={handleKeyDown}
+            onBlur={handleBlur}
+            placeholder={placeholder}
+          />
+        )}
+      </div>
+      {error && <BaseError>{error}</BaseError>}
+    </BaseItem>
+  );
+}

--- a/src/components/ui/Field/Textarea.tsx
+++ b/src/components/ui/Field/Textarea.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, TextareaHTMLAttributes } from 'react';
+import { forwardRef, TextareaHTMLAttributes, useId } from 'react';
 import { cn } from '@/utils/helper';
 import { BaseError, baseErrorClassName, baseFieldClassName, BaseItem, BaseLabel } from './Base';
 import { BaseField } from './types';
@@ -6,10 +6,16 @@ import { BaseField } from './types';
 type TextareaProps = BaseField & TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(({ label, error, className, ...props }, ref) => {
+  const id = useId();
+
   return (
     <BaseItem>
-      {label && <BaseLabel required={props.required}>{label}</BaseLabel>}
-      <textarea {...props} className={cn(baseFieldClassName, 'h-[126px] resize-none', error && baseErrorClassName, className)} ref={ref} />
+      {label && (
+        <BaseLabel required={props.required} htmlFor={id}>
+          {label}
+        </BaseLabel>
+      )}
+      <textarea id={id} {...props} className={cn(baseFieldClassName, 'h-[126px] resize-none', error && baseErrorClassName, className)} ref={ref} />
       {error && <BaseError>{error}</BaseError>}
     </BaseItem>
   );

--- a/src/components/ui/Field/Textarea.tsx
+++ b/src/components/ui/Field/Textarea.tsx
@@ -1,0 +1,18 @@
+import { forwardRef, TextareaHTMLAttributes } from 'react';
+import { cn } from '@/utils/helper';
+import { BaseError, baseErrorClassName, baseFieldClassName, BaseItem, BaseLabel } from './Base';
+import { BaseField } from './types';
+
+type TextareaProps = BaseField & TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(({ label, error, className, ...props }, ref) => {
+  return (
+    <BaseItem>
+      {label && <BaseLabel required={props.required}>{label}</BaseLabel>}
+      <textarea {...props} className={cn(baseFieldClassName, 'h-[126px] resize-none', error && baseErrorClassName, className)} ref={ref} />
+      {error && <BaseError>{error}</BaseError>}
+    </BaseItem>
+  );
+});
+
+Textarea.displayName = 'Textarea';

--- a/src/components/ui/Field/index.ts
+++ b/src/components/ui/Field/index.ts
@@ -1,0 +1,6 @@
+export * from './Input';
+export * from './TagInput';
+export * from './Textarea';
+export * from './ImageUpload';
+export * from './DateInput';
+export * from './SearchInput';

--- a/src/components/ui/Field/types.ts
+++ b/src/components/ui/Field/types.ts
@@ -1,0 +1,4 @@
+export type BaseField = {
+  label?: string;
+  error?: string;
+};


### PR DESCRIPTION
## ❓이슈
- close #29 

## :writing_hand: Description
대시보드 페이지 내부에서 사용할 공용 필드 컴포넌트들을 작업했습니다.
- Input
- Textarea
- TagInput
- DateInput
- ImageUpload
- SearchInput

**전달사항**
- 샘플페이지를 같이 넣어두었습니다. ('/form' 으로 접속하시면 됩니다.)
-  Input, Textarea, SearchInput 컴포넌트는 controlled, uncontrolled 둘다 사용하실 수 있습니다.
- TagInput, DateInput, ImageUpload는 controlled로만 작동합니다.
- controlled 컴포넌트를 RHF(React Hook Form)에 연결하는 샘플은 /app/(dashboard)/form/page.tsx를 확인해주세요
- 검색과 일반 인풋의 스타일 가이드가 맞지 않아서, 하나로 통일했습니다.
- 이미지 업로드시 기존 이미지 삭제를 못하는것 같아서 삭제 버튼을 추가했습니다.
- 이미지 업로드 컴포넌트에 추가 클래스네임을 전달해서 프로필 페이지에도 사용하시면 됩니다.
- 태그인풋은 엔터시 입력되고, 백스페이스로 삭제하는 기능을 넣었어요.
- 나중에 시간이 나면 데이트피커 UI css 커스텀 하겠습니다. (기본UI가 별로 안이뻐요)

**고민했던 방법**
개인적으로 리액트 컴포넌트에서 dom의 외형을 예측할 수 있는 구조를 좋아해서, context를 이용해서 compound형식으로 하고 싶었는데 다른 분들이 사용하시기에 약간 어색하실수도 있을것 같아서 간단하게 작업했습니다.

```
// 고민했던 방법 (컨텍스트 이용)
<FormItem>
  <FormLabel>라벨</FormLabel>
  <Input />
  <FormMessage />
</FormItem>

// 이번 프로젝트에 선택한 방법
<Input 
  label='제목'
  error={errors.title?.message}
/>
```
<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->

## :white_check_mark: Checklist

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [ ] (없음)
