### PR TITLE
Feat/50/dashboard edit

### DIFF
--- a/src/app/(after-login)/dashboard/[id]/edit/page.tsx
+++ b/src/app/(after-login)/dashboard/[id]/edit/page.tsx
@@ -8,7 +8,7 @@ import { getErrorMessage } from '@/utils/errorMessage';
 import DetailModify from '@/components/dashboard/DetailModify';
 import DetailMembers from '@/components/dashboard/DetailMembers';
 import DetailInvited from '@/components/dashboard/DetailInvited';
-import Link from 'next/link';
+import GoBackLink from '@/components/ui/Link/GoBackLink';
 
 export default function DashboardEditPage() {
   const router = useRouter();
@@ -29,9 +29,8 @@ export default function DashboardEditPage() {
 
   return (
     <div className='p-10'>
-      {/* TODO : 돌아가기 공용 컴포넌트로 교체 필요 */}
       <div className='mb-8'>
-        <Link href={`/dashboard/${id}`}>돌아가기</Link>
+        <GoBackLink href={`/dashboard/${id}`} />
       </div>
       <div className='grid w-full max-w-[620px] gap-4'>
         {/* 대시보드 정보 */}
@@ -44,7 +43,6 @@ export default function DashboardEditPage() {
         <DetailInvited />
 
         {/* 대시보드 삭제 */}
-        {/* TODO : 대시보드 공용 버튼 교체 필요 */}
         <Button variant='outline' onClick={handleDelete}>
           대시보드 삭제하기
         </Button>

--- a/src/components/dashboard/MyDashboardList.tsx
+++ b/src/components/dashboard/MyDashboardList.tsx
@@ -2,10 +2,10 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
-import PaginationControls from '@/components/pagination/PaginationControls';
 import MyDashboardCard from '@/components/dashboard/MyDashboardCard';
 import { useDashboardsQuery } from '@/apis/dashboards/queries';
 import DashboardButton from '../ui/Button/DashboardButton';
+import PaginationWithCounter from '../pagination/PaginationWithCounter';
 
 interface MyDashboardListProps {
   onAdd: () => void;
@@ -16,18 +16,6 @@ const ITEMS_PER_PAGE = 5;
 export default function MyDashboardList({ onAdd }: MyDashboardListProps) {
   const [page, setPage] = useState(1);
   const { data, isLoading } = useDashboardsQuery(page, ITEMS_PER_PAGE);
-
-  const totalCount = data?.totalCount || 0;
-  const totalPage = Math.ceil(totalCount / ITEMS_PER_PAGE);
-  const hasNext = page < totalPage;
-  const hasPrev = page > 1;
-
-  const handlePrev = () => {
-    setPage((prev) => prev - 1);
-  };
-  const handleNext = () => {
-    setPage((prev) => prev + 1);
-  };
 
   return (
     <div className='grid gap-3'>
@@ -47,14 +35,12 @@ export default function MyDashboardList({ onAdd }: MyDashboardListProps) {
         ))}
       </ul>
 
-      {totalCount > 0 && (
-        <div className='flex items-center justify-end gap-4'>
-          <span className='text-md text-gray-70'>
-            {totalPage} 페이지중 {page}
-          </span>
-          <PaginationControls canGoPrev={hasPrev} canGoNext={hasNext} handlePrev={handlePrev} handleNext={handleNext} totalPages={totalCount} alwaysShow />
-        </div>
-      )}
+      <PaginationWithCounter //
+        totalCount={data?.totalCount || 0}
+        page={page}
+        setPage={setPage}
+        pageSize={ITEMS_PER_PAGE}
+      />
     </div>
   );
 }

--- a/src/components/dashboard/MyInvitedDashboardList.tsx
+++ b/src/components/dashboard/MyInvitedDashboardList.tsx
@@ -10,6 +10,7 @@ import MyInvitedEmptyCard from './MyInvitedEmptyCard';
 import { SearchInput } from '../ui/Field';
 import useAlert from '@/hooks/useAlert';
 import { getErrorMessage } from '@/utils/errorMessage';
+import { Table, TableBody, TableCell, TableCol, TableColGroup, TableHead, TableHeadCell, TableRow } from '@/components/ui/Table/Table';
 
 export default function MyInvitedDashboardList() {
   const [searchKeyword, setSearchKeyword] = useState('');
@@ -47,26 +48,32 @@ export default function MyInvitedDashboardList() {
       {hasNoInvitations ? (
         <MyInvitedEmptyCard>아직 초대받은 대시보드가 없어요.</MyInvitedEmptyCard>
       ) : (
-        <div className='grid gap-10'>
+        <div className='grid gap-4 md:gap-10'>
           <SearchInput value={searchKeyword} onChange={(e) => setSearchKeyword(e.target.value)} placeholder='검색' />
           {hasNoSearchResults ? (
             <MyInvitedEmptyCard>검색된 초대가 없습니다.</MyInvitedEmptyCard>
           ) : (
-            // TODO : 리스트 테이블 공용 컴포넌트화 필요
-            <div className='flex flex-col gap-6'>
-              <div className='px-8'>
-                <div className='hidden md:block'>
-                  <div className='mb-4 grid grid-cols-[1fr_1fr_2fr] gap-5 text-lg text-gray-40 lg:pl-10'>
-                    <span>이름</span>
-                    <span>초대자</span>
-                    <span>수락 여부</span>
-                  </div>
-                  <div className='flex flex-col gap-5'>
-                    {invitations.map((item) => (
-                      <div key={item.id} className='grid grid-cols-[1fr_1fr_2fr] items-center gap-5 border-b pb-5 text-lg text-gray-70 lg:pl-10'>
-                        <span>{item.dashboard.title}</span>
-                        <span>{item.inviter.nickname}</span>
-                        <div className='flex gap-2.5'>
+            <>
+              <Table responsive>
+                <TableColGroup className='hidden md:table-column-group'>
+                  <TableCol />
+                  <TableCol className='w-[20%]' />
+                  <TableCol className='w-48' />
+                </TableColGroup>
+                <TableHead>
+                  <TableRow>
+                    <TableHeadCell>이름</TableHeadCell>
+                    <TableHeadCell>초대자</TableHeadCell>
+                    <TableHeadCell>수락 여부</TableHeadCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {invitations.map((item) => (
+                    <TableRow key={item.id}>
+                      <TableCell label='이름'>{item.dashboard.title}</TableCell>
+                      <TableCell label='초대자'>{item.inviter.nickname}</TableCell>
+                      <TableCell>
+                        <div className='flex w-full gap-2'>
                           <Button size='sm' onClick={() => handleAccept({ id: item.id, flag: true })}>
                             수락
                           </Button>
@@ -74,15 +81,15 @@ export default function MyInvitedDashboardList() {
                             거절
                           </Button>
                         </div>
-                      </div>
-                    ))}
-                  </div>
-                </div>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
 
-                {/* 공통 load more 트리거 요소 */}
-                <div ref={ref} className='h-8' />
-              </div>
-            </div>
+              {/* 공통 load more 트리거 요소 */}
+              <div ref={ref} className='h-2' />
+            </>
           )}
         </div>
       )}

--- a/src/components/pagination/PaginationWithCounter.tsx
+++ b/src/components/pagination/PaginationWithCounter.tsx
@@ -1,0 +1,33 @@
+import { Dispatch, SetStateAction } from 'react';
+import PaginationControls from './PaginationControls';
+
+interface PaginationWithCounterProps {
+  totalCount: number;
+  page: number;
+  setPage: Dispatch<SetStateAction<number>>;
+  pageSize: number;
+}
+
+export default function PaginationWithCounter({ totalCount, page, setPage, pageSize }: PaginationWithCounterProps) {
+  const totalPage = Math.ceil(totalCount / pageSize);
+  const hasNext = page < totalPage;
+  const hasPrev = page > 1;
+
+  const handlePrev = () => {
+    setPage((prev) => prev - 1);
+  };
+  const handleNext = () => {
+    setPage((prev) => prev + 1);
+  };
+
+  return (
+    <div className='flex items-center justify-end gap-4 font-normal'>
+      {totalCount > 0 && (
+        <span className='text-md text-gray-70'>
+          {totalPage} 페이지중 {page}
+        </span>
+      )}
+      <PaginationControls canGoPrev={hasPrev} canGoNext={hasNext} handlePrev={handlePrev} handleNext={handleNext} totalPages={totalPage} alwaysShow />
+    </div>
+  );
+}

--- a/src/components/provider/QueryProvider.tsx
+++ b/src/components/provider/QueryProvider.tsx
@@ -7,6 +7,7 @@ const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: 60 * 1000, // 1분
+      retry: false,
     },
   },
 });

--- a/src/components/ui/Table/Table.tsx
+++ b/src/components/ui/Table/Table.tsx
@@ -1,0 +1,95 @@
+import { ColgroupHTMLAttributes, ColHTMLAttributes, createContext, HTMLAttributes, PropsWithChildren, TableHTMLAttributes, TdHTMLAttributes, ThHTMLAttributes, useContext } from 'react';
+import { cn } from '@/utils/helper';
+
+interface TableContextProps {
+  responsive: boolean;
+}
+const TableContext = createContext<TableContextProps | null>(null);
+
+const useTable = () => {
+  const ctx = useContext(TableContext);
+
+  if (!ctx) {
+    throw new Error('table context는 table provider 내부에서 사용해주세요');
+  }
+  return ctx;
+};
+
+interface TableProps extends TableHTMLAttributes<HTMLTableElement> {
+  responsive?: boolean;
+}
+
+export function Table({ responsive = false, className, children, ...props }: TableProps) {
+  return (
+    <TableContext.Provider value={{ responsive }}>
+      <table className={cn('w-full table-fixed', className)} {...props}>
+        {children}
+      </table>
+    </TableContext.Provider>
+  );
+}
+
+export function TableColGroup({ className, children, ...props }: PropsWithChildren<ColgroupHTMLAttributes<HTMLTableColElement>>) {
+  const { responsive } = useTable();
+
+  return (
+    <colgroup className={cn(responsive && 'hidden md:table-column-group', className)} {...props}>
+      {children}
+    </colgroup>
+  );
+}
+
+export function TableCol({ className, ...props }: ColHTMLAttributes<HTMLTableColElement>) {
+  return <col className={cn(className)} {...props} />;
+}
+
+export function TableHead({ className, children, ...props }: PropsWithChildren<HTMLAttributes<HTMLTableSectionElement>>) {
+  const { responsive } = useTable();
+
+  return (
+    <thead className={cn(responsive && 'hidden md:table-header-group', className)} {...props}>
+      {children}
+    </thead>
+  );
+}
+
+export function TableBody({ className, children, ...props }: PropsWithChildren<HTMLAttributes<HTMLTableSectionElement>>) {
+  return (
+    <tbody className={cn('divide-y divide-gray-300', className)} {...props}>
+      {children}
+    </tbody>
+  );
+}
+
+export function TableHeadCell({ className, children, ...props }: PropsWithChildren<ThHTMLAttributes<HTMLTableCellElement>>) {
+  return (
+    <th className={cn('text-left font-normal text-gray-40', className)} {...props}>
+      {children}
+    </th>
+  );
+}
+
+export function TableRow({ className, children, ...props }: PropsWithChildren<HTMLAttributes<HTMLTableRowElement>>) {
+  const { responsive } = useTable();
+
+  return (
+    <tr className={cn(responsive && 'block py-4 md:table-row md:py-0', className)} {...props}>
+      {children}
+    </tr>
+  );
+}
+
+interface TableCellProps extends TdHTMLAttributes<HTMLTableCellElement> {
+  label?: string;
+}
+
+export function TableCell({ className, label, children, ...props }: TableCellProps) {
+  const { responsive } = useTable();
+
+  return (
+    <td className={cn('break-words py-5', responsive && 'flex w-full py-2 md:table-cell md:py-5', className)} {...props}>
+      {responsive && label && <span className='block w-[4em] font-normal text-gray-40 md:hidden'>{label}</span>}
+      {children}
+    </td>
+  );
+}


### PR DESCRIPTION
## ❓이슈
- close #50
- close #52 
- close #53 
- close #93

## :writing_hand: Description
아래 컴포넌트 작업했습니다.

- 대시보드 수정 페이지 - 대시보드 정보수정 (api 연동 완료)
- 대시보드 수정 페이지 - 초대내역 리스트 (api 연동 완료)
- 대시보드 수정 페이지 - 대시보드 삭제하기 (api 연동 및 리다이렉션 까지 완료)
- 공용 테이블 컴포넌트 추가
- 공용 카운터 페이지네이션 추가 (기존 페이지네이션을 확장)

**전달사항**
- 초대내역과 테이블의 외형을 조금 바꾸었습니다. (더 보기 좋게)
- 테이블은 responsive 옵션을 주면 반응형으로 작동하게 해두었습니다.
<img width="634" alt="스크린샷 2025-02-11 오전 12 59 01" src="https://github.com/user-attachments/assets/09775087-888b-4dc5-9ef6-ae0ca7d054e3" />

<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->

## :white_check_mark: Checklist

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [ ] (없음)
