### PR TITLE
Fix/179/todo card fix

### DIFF
--- a/src/components/todo/TodoCard.tsx
+++ b/src/components/todo/TodoCard.tsx
@@ -33,16 +33,16 @@ export default function TodoCard({ card }: TodoCardProps) {
         onClick={() => detailTodoModalRef.current?.open()}
       >
         {card.imageUrl !== DEFAULT_CARD_IMAGE_URL && <Image src={card.imageUrl} alt={card.title} className='w-full md:w-[120px] lg:w-full' width={400} height={200} />}
-        <div className='flex flex-col gap-1.5 md:flex-1 md:flex-row lg:flex-col lg:gap-2'>
-          <div className='flex flex-col gap-1.5 md:flex-none lg:gap-2.5'>
+        <div className='flex flex-col gap-1.5 md:flex-1 md:flex-row md:gap-4 lg:flex-col lg:gap-2'>
+          <div className='flex flex-col gap-1.5 md:justify-between lg:gap-1.5'>
             <span className='break-words break-all text-md font-medium text-gray-70 lg:text-lg lg:leading-5'>{card.title}</span>
-            <div className='flex flex-wrap gap-1.5 break-words'>
+            <div className='flex flex-wrap gap-1.5 break-words md:max-w-[500px]'>
               {card.tags.map((tag) => (
                 <TagChip key={tag} label={tag} />
               ))}
             </div>
           </div>
-          <div className='flex justify-between md:flex-auto md:items-end'>
+          <div className='flex justify-between gap-3 md:flex-auto md:items-end'>
             <div className='flex items-center gap-1'>
               <Image src={calendar} width={10} height={11} alt='캘린더' />
               <span className='text-xs font-medium text-gray-50'>{formattedDate}</span>


### PR DESCRIPTION
## ❓이슈
- close #179 

## :writing_hand: Description

- 카드의 이미지 height가 높으면 컨텐츠가 밀리는 현상 개선
- 태그 개수가 많을시 flex-wrap 속성을 무시하고 카드 범위를 넘어버리는 현상 개선

- 우선 피그마 시안을 최대한 지킨다면 태그 갯수가 wrap으로 넘어가도록 많아지는 상황이 별로 없을 것 같지만 넘어간다면 dueDate가 프로필 아이콘 옆에 붙어있도록 하는게 최선인거 같습니당(사진 참고)
- 그렇지 않고 wrap으로 넘어가도록 태그 갯수가 많지 않은경우는 시안과 똑같이 동작합니다
![스크린샷 2025-02-18 17 12 41](https://github.com/user-attachments/assets/c7f4aa57-53fa-47cd-9564-1bfafd8e4839)
![스크린샷 2025-02-18 17 14 54](https://github.com/user-attachments/assets/f0dca7a6-4301-4836-898a-fcacf1fb34fd)


## :white_check_mark: Checklist

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [ ] 로컬 작동 확인

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [ ] (없음)
